### PR TITLE
feat(visitor experience): add (hopefully!) self-explanatory error message

### DIFF
--- a/src/components/ErrorPage.jsx
+++ b/src/components/ErrorPage.jsx
@@ -9,8 +9,13 @@ export default function ErrorPage() {
     <div id="error-page">
       <h1>Oops!</h1>
       <p>Sorry, an unexpected error has occurred.</p>
+
       <p>
         <i>{error.statusText || error.message}</i>
+          {error.message == 'Failed to fetch' &&
+        <p>(Please note that network access to <i>https://restcountries.com/</i> is required<br />
+          so that `Where in the world?` app behaves as expected)
+        </p>}
       </p>
     </div>
   );


### PR DESCRIPTION
Hi! 

This pull-request
fixes: https://github.com/techemmy/React-Countries-Finder/issues/1

When restcountries.com domain medias could not be accessed,
merging this pull-request would allow to 
render a specific error message about it warning visitors.

![image](https://github.com/techemmy/React-Countries-Finder/assets/1053622/c7632efd-6324-46fa-adff-983d5b5e94f3)